### PR TITLE
Feature: Local Multiplayer Support

### DIFF
--- a/Sources/GPGXBridge/GPGXEmulatorBridge.m
+++ b/Sources/GPGXBridge/GPGXEmulatorBridge.m
@@ -131,22 +131,22 @@ int GPGXGameSaveSize = 0x10000;
 
 #pragma mark - Inputs -
 
-- (void)activateInput:(NSInteger)inputValue value:(double)value
+- (void)activateInput:(NSInteger)inputValue value:(double)value at:(NSInteger)playerIndex
 {
-    int player = 0;
-    input.pad[player * 4] |= inputValue;
+    input.pad[playerIndex * 4] |= inputValue;
 }
 
-- (void)deactivateInput:(NSInteger)inputValue
+- (void)deactivateInput:(NSInteger)inputValue at:(NSInteger)playerIndex
 {
-    int player = 0;
-    input.pad[player * 4] &= ~inputValue;
+    input.pad[playerIndex * 4] &= ~inputValue;
 }
 
 - (void)resetInputs
 {
-    int player = 0;
-    input.pad[player * 4] = 0;
+    for(int player = 0; player < 2; player++)
+    {
+        input.pad[player * 4] = 0;
+    }
 }
 
 #pragma mark - Game Saves -

--- a/Sources/GPGXBridge/GPGXEmulatorBridge.m
+++ b/Sources/GPGXBridge/GPGXEmulatorBridge.m
@@ -145,7 +145,7 @@ int GPGXGameSaveSize = 0x10000;
 {
     for (int playerIndex = 0; playerIndex < 2; playerIndex++)
     {
-        input.pad[player * 4] = 0;
+        input.pad[playerIndex * 4] = 0;
     }
 }
 

--- a/Sources/GPGXBridge/GPGXEmulatorBridge.m
+++ b/Sources/GPGXBridge/GPGXEmulatorBridge.m
@@ -143,7 +143,7 @@ int GPGXGameSaveSize = 0x10000;
 
 - (void)resetInputs
 {
-    for(int player = 0; player < 2; player++)
+    for (int playerIndex = 0; playerIndex < 2; playerIndex++)
     {
         input.pad[player * 4] = 0;
     }

--- a/Sources/GPGXBridge/GPGXEmulatorBridge.m
+++ b/Sources/GPGXBridge/GPGXEmulatorBridge.m
@@ -131,12 +131,12 @@ int GPGXGameSaveSize = 0x10000;
 
 #pragma mark - Inputs -
 
-- (void)activateInput:(NSInteger)inputValue value:(double)value at:(NSInteger)playerIndex
+- (void)activateInput:(NSInteger)inputValue value:(double)value playerIndex:(NSInteger)playerIndex
 {
     input.pad[playerIndex * 4] |= inputValue;
 }
 
-- (void)deactivateInput:(NSInteger)inputValue at:(NSInteger)playerIndex
+- (void)deactivateInput:(NSInteger)inputValue playerIndex:(NSInteger)playerIndex
 {
     input.pad[playerIndex * 4] &= ~inputValue;
 }


### PR DESCRIPTION
This PR (in a series of PRs for Local Multiplayer Support) conforms to the updated EmulatorBridging protocol to allow for local multiplayer support, and implements sending per-player inputs to the emulator core.

Not opened in any PR is protocol conformance in the GBC, GBA, and melonDS cores. While local multiplayer support does not exist on those cores, they will still need to adopt the protocol, and may simply ignore the new incoming `playerIndex` var.

Other PRs:
- Delta: https://github.com/rileytestut/Delta/pull/128
- DeltaCore: https://github.com/rileytestut/DeltaCore/pull/32
- NES: https://github.com/rileytestut/NESDeltaCore/pull/2
- SNES: https://github.com/rileytestut/SNESDeltaCore/pull/2
- N64: https://github.com/rileytestut/N64DeltaCore/pull/5
- GEN: https://github.com/rileytestut/GPGXDeltaCore/pull/1

Relevant Trello Cards:
- https://trello.com/c/VtDLcykr/71-feature-nes-local-multiplayer
- https://trello.com/c/pwA1ts98/70-feature-snes-local-multiplayer
- https://trello.com/c/Mu9dQ1aZ/72-feature-n64-local-multiplayer