### PR TITLE
Cheats

### DIFF
--- a/Sources/GPGXBridge/GPGXEmulatorBridge.m
+++ b/Sources/GPGXBridge/GPGXEmulatorBridge.m
@@ -23,6 +23,40 @@
 
 #endif
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
+#import "shared.h"
+#pragma clang diagnostic pop
+
+#define u8 uint8_t
+#define u16 uint16_t
+#define u32 uint32_t
+#define u64 uint64_t
+
+#define MAX_CHEATS (350)
+#define MAX_DESC_LENGTH (63)
+
+static char ggvalidchars[] = "ABCDEFGHJKLMNPRSTVWXYZ0123456789";
+static char arvalidchars[] = "0123456789ABCDEF";
+
+static int maxcheats = 0;
+static int maxROMcheats = 0;
+static int maxRAMcheats = 0;
+
+typedef struct
+{
+  char code[12];
+  char text[MAX_DESC_LENGTH];
+  u8 enable;
+  u16 data;
+  u16 old;
+  u32 address;
+  u8 *prev;
+} CHEATENTRY;
+
+static CHEATENTRY cheatlist[MAX_CHEATS];
+static u8 cheatIndexes[MAX_CHEATS];
+
 CGFloat GPGXVideoWidth = 720;
 CGFloat GPGXVideoHeight = 576;
 
@@ -37,6 +71,8 @@ int GPGXGameSaveSize = 0x10000;
 
 @property (nonatomic, readonly) NSMutableData *audioBuffer;
 @property (nonatomic, readonly) NSMutableData *videoBuffer;
+
+@property (nonatomic, readwrite) NSInteger cheatCount;
 
 @end
 
@@ -63,6 +99,7 @@ int GPGXGameSaveSize = 0x10000;
     {
         _audioBuffer = [[NSMutableData alloc] initWithLength:2048 * 2 * sizeof(int16_t)];
         _videoBuffer = [[NSMutableData alloc] initWithLength:GPGXVideoWidth * GPGXVideoHeight * sizeof(uint32_t)];
+        _cheatCount = 0;
     }
     
     return self;
@@ -110,6 +147,8 @@ int GPGXGameSaveSize = 0x10000;
 
 - (void)runFrameAndProcessVideo:(BOOL)processVideo
 {
+    RAMCheatUpdate();
+    
     if (system_hw == SYSTEM_MCD)
     {
         system_frame_scd(!processVideo);
@@ -221,15 +260,45 @@ int GPGXGameSaveSize = 0x10000;
 
 - (BOOL)addCheatCode:(NSString *)cheatCode type:(NSString *)type
 {
+    
+    
+    NSMutableString *mutableCheatCode = [cheatCode mutableCopy];
+    
+//    if ([type isEqualToString:CheatTypeActionReplay])
+//    {
+//        //
+//    }
+//    else if ([type isEqualToString:CheatTypeGameGenie])
+//    {
+//        [mutableCheatCode insertString:@"-" atIndex:4];
+//    }
+//    
+    NSInteger length = decode_cheat(mutableCheatCode.UTF8String, self.cheatCount);
+    if (length == 0)
+    {
+        NSLog(@"Failed to decode cheat: %@", cheatCode);
+        return NO;
+    }
+    
+    cheatlist[self.cheatCount].enable = 1;
+    
+    self.cheatCount++;
+    maxcheats++;
+    
     return YES;
 }
 
 - (void)resetCheats
 {
+    clear_cheats();
+    self.cheatCount = 0;
+    maxcheats = 0;
 }
 
 - (void)updateCheats
 {
+    apply_cheats();
+    ROMCheatUpdate();
 }
 
 #pragma mark - Getters/Setters -
@@ -243,6 +312,363 @@ int GPGXGameSaveSize = 0x10000;
 
 void osd_input_update(void)
 {
+}
+
+static u32 decode_cheat(char *string, int index)
+{
+  char *p;
+  int i,n;
+  u32 len = 0;
+  u32 address = 0;
+  u16 data = 0;
+  u8 ref = 0;
+
+  /* 16-bit Game Genie code (ABCD-EFGH) */
+  if ((strlen(string) >= 9) && (string[4] == '-'))
+  {
+    /* 16-bit system only */
+    if ((system_hw & SYSTEM_PBC) != SYSTEM_MD)
+    {
+      return 0;
+    }
+
+    for (i = 0; i < 8; i++)
+    {
+      if (i == 4) string++;
+      p = strchr (ggvalidchars, *string++);
+      if (p == NULL) return 0;
+      n = p - ggvalidchars;
+
+      switch (i)
+      {
+        case 0:
+        data |= n << 3;
+        break;
+
+        case 1:
+        data |= n >> 2;
+        address |= (n & 3) << 14;
+        break;
+
+        case 2:
+        address |= n << 9;
+        break;
+
+        case 3:
+        address |= (n & 0xF) << 20 | (n >> 4) << 8;
+        break;
+    
+        case 4:
+        data |= (n & 1) << 12;
+        address |= (n >> 1) << 16;
+        break;
+
+        case 5:
+        data |= (n & 1) << 15 | (n >> 1) << 8;
+        break;
+
+        case 6:
+        data |= (n >> 3) << 13;
+        address |= (n & 7) << 5;
+        break;
+
+        case 7:
+        address |= n;
+        break;
+      }
+    }
+
+    /* code length */
+    len = 9;
+  }
+
+  /* 8-bit Game Genie code (DDA-AAA-XXX) */
+  else if ((strlen(string) >= 11) && (string[3] == '-') && (string[7] == '-'))
+  {
+    /* 8-bit system only */
+    if ((system_hw & SYSTEM_PBC) == SYSTEM_MD)
+    {
+      return 0;
+    }
+
+    /* decode 8-bit data */
+    for (i=0; i<2; i++)
+    {
+      p = strchr (arvalidchars, *string++);
+      if (p == NULL) return 0;
+      n = (p - arvalidchars) & 0xF;
+      data |= (n  << ((1 - i) * 4));
+    }
+
+    /* decode 16-bit address (low 12-bits) */
+    for (i=0; i<3; i++)
+    {
+      if (i==1) string++; /* skip separator */
+      p = strchr (arvalidchars, *string++);
+      if (p == NULL) return 0;
+      n = (p - arvalidchars) & 0xF;
+      address |= (n  << ((2 - i) * 4));
+    }
+
+    /* decode 16-bit address (high 4-bits) */
+    p = strchr (arvalidchars, *string++);
+    if (p == NULL) return 0;
+    n = (p - arvalidchars) & 0xF;
+    n ^= 0xF; /* bits inversion */
+    address |= (n  << 12);
+
+    /* RAM address are also supported */
+    if (address >= 0xC000)
+    {
+      /* convert to 24-bit Work RAM address */
+      address = 0xFF0000 | (address & 0x1FFF);
+    }
+
+    /* decode reference 8-bit data */
+    for (i=0; i<2; i++)
+    {
+      string++; /* skip separator and 2nd digit */
+      p = strchr (arvalidchars, *string++);
+      if (p == NULL) return 0;
+      n = (p - arvalidchars) & 0xF;
+      ref |= (n  << ((1 - i) * 4));
+    }
+    ref = (ref >> 2) | ((ref & 0x03) << 6);  /* 2-bit right rotation */
+    ref ^= 0xBA;  /* XOR */
+
+    /* update old data value */
+    cheatlist[index].old = ref;
+
+    /* code length */
+    len = 11;
+  }
+
+  /* Action Replay code */
+  else if (string[6] == ':')
+  {
+    if ((system_hw & SYSTEM_PBC) == SYSTEM_MD)
+    {
+      /* 16-bit code (AAAAAA:DDDD) */
+      if (strlen(string) < 11) return 0;
+
+      /* decode 24-bit address */
+      for (i=0; i<6; i++)
+      {
+        p = strchr (arvalidchars, *string++);
+        if (p == NULL) return 0;
+        n = (p - arvalidchars) & 0xF;
+        address |= (n << ((5 - i) * 4));
+      }
+
+      /* decode 16-bit data */
+      string++;
+      for (i=0; i<4; i++)
+      {
+        p = strchr (arvalidchars, *string++);
+        if (p == NULL) return 0;
+        n = (p - arvalidchars) & 0xF;
+        data |= (n << ((3 - i) * 4));
+      }
+
+      /* code length */
+      len = 11;
+    }
+    else
+    {
+      /* 8-bit code (xxAAAA:DD) */
+      if (strlen(string) < 9) return 0;
+
+      /* decode 16-bit address */
+      string+=2;
+      for (i=0; i<4; i++)
+      {
+        p = strchr (arvalidchars, *string++);
+        if (p == NULL) return 0;
+        n = (p - arvalidchars) & 0xF;
+        address |= (n << ((3 - i) * 4));
+      }
+
+      /* ROM addresses are not supported */
+      if (address < 0xC000) return 0;
+
+      /* convert to 24-bit Work RAM address */
+      address = 0xFF0000 | (address & 0x1FFF);
+
+      /* decode 8-bit data */
+      string++;
+      for (i=0; i<2; i++)
+      {
+        p = strchr (arvalidchars, *string++);
+        if (p == NULL) return 0;
+        n = (p - arvalidchars) & 0xF;
+        data |= (n  << ((1 - i) * 4));
+      }
+
+      /* code length */
+      len = 9;
+    }
+  }
+
+  /* Valid code found ? */
+  if (len)
+  {
+    /* update cheat address & data values */
+    cheatlist[index].address = address;
+    cheatlist[index].data = data;
+  }
+
+  /* return code length (0 = invalid) */
+  return len;
+}
+
+static void apply_cheats(void)
+{
+  u8 *ptr;
+  
+  /* clear ROM&RAM patches counter */
+  maxROMcheats = maxRAMcheats = 0;
+
+  int i;
+  for (i = 0; i < maxcheats; i++)
+  {
+    if (cheatlist[i].enable)
+    {
+      if (cheatlist[i].address < cart.romsize)
+      {
+        if ((system_hw & SYSTEM_PBC) == SYSTEM_MD)
+        {
+          /* patch ROM data */
+          cheatlist[i].old = *(u16 *)(cart.rom + (cheatlist[i].address & 0xFFFFFE));
+          *(u16 *)(cart.rom + (cheatlist[i].address & 0xFFFFFE)) = cheatlist[i].data;
+        }
+        else
+        {
+          /* add ROM patch */
+          maxROMcheats++;
+          cheatIndexes[MAX_CHEATS - maxROMcheats] = i;
+
+          /* get current banked ROM address */
+          ptr = &z80_readmap[(cheatlist[i].address) >> 10][cheatlist[i].address & 0x03FF];
+
+          /* check if reference matches original ROM data */
+          if (((u8)cheatlist[i].old) == *ptr)
+          {
+            /* patch data */
+            *ptr = cheatlist[i].data;
+
+            /* save patched ROM address */
+            cheatlist[i].prev = ptr;
+          }
+          else
+          {
+            /* no patched ROM address yet */
+            cheatlist[i].prev = NULL;
+          }
+        }
+      }
+      else if (cheatlist[i].address >= 0xFF0000)
+      {
+        /* add RAM patch */
+        cheatIndexes[maxRAMcheats++] = i;
+      }
+    }
+  }
+}
+
+static void clear_cheats(void)
+{
+  int i = maxcheats;
+
+  /* disable cheats in reversed order in case the same address is used by multiple patches */
+  while (i > 0)
+  {
+    if (cheatlist[i-1].enable)
+    {
+      if (cheatlist[i-1].address < cart.romsize)
+      {
+        if ((system_hw & SYSTEM_PBC) == SYSTEM_MD)
+        {
+          /* restore original ROM data */
+          *(u16 *)(cart.rom + (cheatlist[i-1].address & 0xFFFFFE)) = cheatlist[i-1].old;
+        }
+        else
+        {
+          /* check if previous banked ROM address has been patched */
+          if (cheatlist[i-1].prev != NULL)
+          {
+            /* restore original data */
+            *cheatlist[i-1].prev = cheatlist[i-1].old;
+
+            /* no more patched ROM address */
+            cheatlist[i-1].prev = NULL;
+          }
+        }
+      }
+    }
+
+    i--;
+  }
+}
+
+void RAMCheatUpdate(void)
+{
+  int index, cnt = maxRAMcheats;
+  
+  while (cnt)
+  {
+    /* get cheat index */
+    index = cheatIndexes[--cnt];
+
+    /* apply RAM patch */
+    if (cheatlist[index].data & 0xFF00)
+    {
+      /* word patch */
+      *(u16 *)(work_ram + (cheatlist[index].address & 0xFFFE)) = cheatlist[index].data;
+    }
+    else
+    {
+      /* byte patch */
+      work_ram[cheatlist[index].address & 0xFFFF] = cheatlist[index].data;
+    }
+  }
+}
+
+void ROMCheatUpdate(void)
+{
+  int index, cnt = maxROMcheats;
+  u8 *ptr;
+  
+  while (cnt)
+  {
+    /* get cheat index */
+    index = cheatIndexes[MAX_CHEATS - cnt];
+
+    /* check if previous banked ROM address was patched */
+    if (cheatlist[index].prev != NULL)
+    {
+      /* restore original data */
+      *cheatlist[index].prev = cheatlist[index].old;
+
+      /* no more patched ROM address */
+      cheatlist[index].prev = NULL;
+    }
+
+    /* get current banked ROM address */
+    ptr = &z80_readmap[(cheatlist[index].address) >> 10][cheatlist[index].address & 0x03FF];
+
+    /* check if reference matches original ROM data */
+    if (((u8)cheatlist[index].old) == *ptr)
+    {
+      /* patch data */
+      *ptr = cheatlist[index].data;
+
+      /* save patched ROM address */
+      cheatlist[index].prev = ptr;
+    }
+
+    /* next ROM patch */
+    cnt--;
+  }
 }
 
 @end

--- a/Sources/GPGXBridge/GPGXEmulatorBridge.m
+++ b/Sources/GPGXBridge/GPGXEmulatorBridge.m
@@ -263,7 +263,7 @@ int GPGXGameSaveSize = 0x10000;
     NSMutableCharacterSet *legalCharacterSet = nil;
     if ([type isEqualToString:CheatTypeActionReplay])
     {
-        legalCharacterSet = [[NSMutableCharacterSet hexadecimalCharacterSet] mutableCopy];
+        legalCharacterSet = [[NSMutableCharacterSet characterSetWithCharactersInString:[NSString stringWithUTF8String:arvalidchars]] mutableCopy];
         [legalCharacterSet addCharactersInString:@":"];
     }
     else if ([type isEqualToString:CheatTypeGameGenie])
@@ -278,74 +278,69 @@ int GPGXGameSaveSize = 0x10000;
     }
 
     [legalCharacterSet addCharactersInString:@" "];
-
-    NSArray<NSString *> *codes = [cheatCode componentsSeparatedByString:@"\n"];
     BOOL addedCheat = NO;
     
-    for (NSString *code in codes)
+    NSString *normalized = [[cheatCode stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] uppercaseString];
+    if (normalized.length == 0)
     {
-        NSString *normalized = [[code stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] uppercaseString];
-        if (normalized.length == 0)
-        {
-            continue;
-        }
-
-        NSRange illegalRange = [normalized rangeOfCharacterFromSet:[legalCharacterSet invertedSet]];
-        if (illegalRange.location != NSNotFound)
-        {
-            NSLog(@"Offending character: %C", [normalized characterAtIndex:illegalRange.location]);
-            return NO;
-        }
-
-        NSString *sanitizedCode = [normalized stringByReplacingOccurrencesOfString:@" " withString:@""];
-
-        if ([type isEqualToString:CheatTypeGameGenie])
-        {
-            BOOL is16BitFormat = (sanitizedCode.length == 9 && [sanitizedCode characterAtIndex:4] == '-');
-            // We can cut this or comment it out for now, as we
-            // don't really support the Sega Game Gear (8-bit)
-            BOOL is8BitFormat = (sanitizedCode.length == 11 &&
-                                 [sanitizedCode characterAtIndex:3] == '-' &&
-                                 [sanitizedCode characterAtIndex:7] == '-');
-            if (!is16BitFormat && !is8BitFormat)
-            {
-                NSLog(@"Invalid Game Genie format: %@", sanitizedCode);
-                return NO;
-            }
-        }
-        else if ([type isEqualToString:CheatTypeActionReplay])
-        {
-            BOOL isValidLength = (sanitizedCode.length == 9 || sanitizedCode.length == 11);
-            BOOL hasExpectedSeparator = (sanitizedCode.length > 6 && [sanitizedCode characterAtIndex:6] == ':');
-            if (!isValidLength || !hasExpectedSeparator)
-            {
-                NSLog(@"Invalid Action Replay format: %@", sanitizedCode);
-                return NO;
-            }
-        }
-
-        char cheatCString[32];
-        if (![sanitizedCode getCString:cheatCString maxLength:sizeof(cheatCString) encoding:NSUTF8StringEncoding])
-        {
-            NSLog(@"Failed to convert to cString: %@", sanitizedCode);
-            return NO;
-        }
-
-        int cheatCount = (int)self.cheatCount;
-        NSInteger length = decode_cheat(cheatCString, cheatCount);
-        if (length == 0)
-        {
-            NSLog(@"Failed to decode cheat: %@", sanitizedCode);
-            return NO;
-        }
-
-        cheatlist[self.cheatCount].enable = 1;
-        // The bridge owns this!
-        self.cheatCount++;
-        // The C-core owns this! Without this, the cheats don't apply at all.
-        maxcheats++;
-        addedCheat = YES;
+        return NO;
     }
+
+    NSRange illegalRange = [normalized rangeOfCharacterFromSet:[legalCharacterSet invertedSet]];
+    if (illegalRange.location != NSNotFound)
+    {
+        NSLog(@"Offending character: %C", [normalized characterAtIndex:illegalRange.location]);
+        return NO;
+    }
+
+    NSString *sanitizedCode = [normalized stringByReplacingOccurrencesOfString:@" " withString:@""];
+    
+    if ([type isEqualToString:CheatTypeGameGenie])
+    {
+        BOOL is16BitFormat = (sanitizedCode.length == 9 && [sanitizedCode characterAtIndex:4] == '-');
+        // We can cut this or comment it out for now, as we
+        // don't really support the Sega Game Gear (8-bit)
+        BOOL is8BitFormat = (sanitizedCode.length == 11 &&
+                             [sanitizedCode characterAtIndex:3] == '-' &&
+                             [sanitizedCode characterAtIndex:7] == '-');
+        if (!is16BitFormat && !is8BitFormat)
+        {
+            NSLog(@"Invalid Game Genie format: %@", sanitizedCode);
+            return NO;
+        }
+    }
+    else if ([type isEqualToString:CheatTypeActionReplay])
+    {
+        BOOL isValidLength = (sanitizedCode.length == 9 || sanitizedCode.length == 11);
+        BOOL hasExpectedSeparator = (sanitizedCode.length > 6 && [sanitizedCode characterAtIndex:6] == ':');
+        if (!isValidLength || !hasExpectedSeparator)
+        {
+            NSLog(@"Invalid Action Replay format: %@", sanitizedCode);
+            return NO;
+        }
+    }
+    
+    char cheatCString[32];
+    if (![sanitizedCode getCString:cheatCString maxLength:sizeof(cheatCString) encoding:NSUTF8StringEncoding])
+    {
+        NSLog(@"Failed to convert to cString: %@", sanitizedCode);
+        return NO;
+    }
+    
+    int cheatCount = (int)self.cheatCount;
+    NSInteger length = decode_cheat(cheatCString, cheatCount);
+    if (length == 0)
+    {
+        NSLog(@"Failed to decode cheat: %@", sanitizedCode);
+        return NO;
+    }
+
+    cheatlist[self.cheatCount].enable = 1;
+    // The bridge owns this!
+    self.cheatCount++;
+    // The C-core owns this! Without this, the cheats don't apply at all.
+    maxcheats++;
+    addedCheat = YES;
     
     return addedCheat;
 }
@@ -376,6 +371,7 @@ void osd_input_update(void)
 {
 }
 
+// Adapted from GPGX: gx/gui/cheats.c
 static u32 decode_cheat(char *string, int index)
 {
   char *p;
@@ -583,6 +579,7 @@ static u32 decode_cheat(char *string, int index)
   return len;
 }
 
+// Adapted from GPGX: gx/gui/cheats.c
 static void apply_cheats(void)
 {
   u8 *ptr;
@@ -637,6 +634,7 @@ static void apply_cheats(void)
   }
 }
 
+// Adapted from GPGX: gx/gui/cheats.c
 static void clear_cheats(void)
 {
   int i = maxcheats;
@@ -672,6 +670,7 @@ static void clear_cheats(void)
   }
 }
 
+// Adapted from GPGX: gx/gui/cheats.c
 void RAMCheatUpdate(void)
 {
   int index, cnt = maxRAMcheats;
@@ -695,6 +694,7 @@ void RAMCheatUpdate(void)
   }
 }
 
+// Adapted from GPGX: gx/gui/cheats.c
 void ROMCheatUpdate(void)
 {
   int index, cnt = maxROMcheats;

--- a/Sources/GPGXBridge/GPGXEmulatorBridge.m
+++ b/Sources/GPGXBridge/GPGXEmulatorBridge.m
@@ -260,91 +260,94 @@ int GPGXGameSaveSize = 0x10000;
 
 - (BOOL)addCheatCode:(NSString *)cheatCode type:(NSString *)type
 {
+    NSMutableCharacterSet *legalCharacterSet = nil;
+    if ([type isEqualToString:CheatTypeActionReplay])
+    {
+        legalCharacterSet = [[NSMutableCharacterSet hexadecimalCharacterSet] mutableCopy];
+        [legalCharacterSet addCharactersInString:@":"];
+    }
+    else if ([type isEqualToString:CheatTypeGameGenie])
+    {
+        legalCharacterSet = [[NSMutableCharacterSet characterSetWithCharactersInString:[NSString stringWithUTF8String:ggvalidchars]] mutableCopy];
+        [legalCharacterSet addCharactersInString:@"-"];
+    }
+    else
+    {
+        NSLog(@"Unsupported cheat type: %@", type);
+        return NO;
+    }
+
+    [legalCharacterSet addCharactersInString:@" "];
+
     NSArray<NSString *> *codes = [cheatCode componentsSeparatedByString:@"\n"];
+    BOOL addedCheat = NO;
     
     for (NSString *code in codes)
     {
-        // Normalize input first: trim whitespace/newlines and uppercase for consistent validation
         NSString *normalized = [[code stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] uppercaseString];
-
-        // Build legal character set based on type
-        NSMutableCharacterSet *legalCharacters = nil;
-        if ([type isEqualToString:CheatTypeActionReplay])
+        if (normalized.length == 0)
         {
-            legalCharacters = [[NSMutableCharacterSet hexadecimalCharacterSet] mutableCopy];
-            [legalCharacters addCharactersInString:@":"];
-        }
-        else if ([type isEqualToString:CheatTypeGameGenie])
-        {
-            legalCharacters = [[NSMutableCharacterSet characterSetWithCharactersInString:[NSString stringWithUTF8String:ggvalidchars]] mutableCopy];
-            [legalCharacters addCharactersInString:@"-"];
-        }
-        else
-        {
-            // Not a supported type!
-            return NO;
+            continue;
         }
 
-        // Allow spaces (we'll strip them) during validation
-        NSMutableCharacterSet *legalCharactersSet = [legalCharacters mutableCopy];
-        [legalCharactersSet addCharactersInString:@" "];
-
-        // Validate characters against the allowed set
-        NSRange illegalRange = [normalized rangeOfCharacterFromSet:[legalCharactersSet invertedSet]];
+        NSRange illegalRange = [normalized rangeOfCharacterFromSet:[legalCharacterSet invertedSet]];
         if (illegalRange.location != NSNotFound)
         {
-            unichar offendingCharacter = [normalized characterAtIndex:illegalRange.location];
-            NSLog(@"Offending character: %C", offendingCharacter);
+            NSLog(@"Offending character: %C", [normalized characterAtIndex:illegalRange.location]);
             return NO;
         }
-        
-        if ([type isEqualToString:CheatTypeActionReplay] || [type isEqualToString:CheatTypeGameGenie])
-        {
-            // Remove spaces; keep hyphens because decode_cheat expects them for 16-bit GG (ABCD-EFGH)
-            NSString *sanitizedCode = [[normalized stringByReplacingOccurrencesOfString:@" " withString:@""] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 
-            // Basic length checks per type
-            if ([type isEqualToString:CheatTypeGameGenie])
+        NSString *sanitizedCode = [normalized stringByReplacingOccurrencesOfString:@" " withString:@""];
+
+        if ([type isEqualToString:CheatTypeGameGenie])
+        {
+            BOOL is16BitFormat = (sanitizedCode.length == 9 && [sanitizedCode characterAtIndex:4] == '-');
+            // We can cut this or comment it out for now, as we
+            // don't really support the Sega Game Gear (8-bit)
+            BOOL is8BitFormat = (sanitizedCode.length == 11 &&
+                                 [sanitizedCode characterAtIndex:3] == '-' &&
+                                 [sanitizedCode characterAtIndex:7] == '-');
+            if (!is16BitFormat && !is8BitFormat)
             {
-                // Accept 16-bit GG codes in form ABCD-EFGH (length 9)
-                if (sanitizedCode.length != 9)
-                {
-                    return NO;
-                }
-            }
-            else if ([type isEqualToString:CheatTypeActionReplay])
-            {
-                // Expect MD AR as AAAAAA:DDDD (length 11) or SMS as xxAAAA:DD (length 9)
-                if (!(sanitizedCode.length == 11 || sanitizedCode.length == 9))
-                {
-                    return NO;
-                }
-            }
-            
-            char cheatCString[32];
-            if (![sanitizedCode getCString:cheatCString maxLength:sizeof(cheatCString) encoding:NSUTF8StringEncoding])
-            {
-                NSLog(@"Failed to convert to cString: %@", sanitizedCode);
+                NSLog(@"Invalid Game Genie format: %@", sanitizedCode);
                 return NO;
             }
-            int cheatCount = (int)self.cheatCount;
-            NSInteger length = decode_cheat(cheatCString, cheatCount);
-            if (length == 0)
-            {
-                NSLog(@"Failed to decode cheat: %@", sanitizedCode);
-                return NO;
-            }
-            
-            cheatlist[self.cheatCount].enable = 1;
-                     
-            self.cheatCount++;
-            
-            return YES;
-            
         }
+        else if ([type isEqualToString:CheatTypeActionReplay])
+        {
+            BOOL isValidLength = (sanitizedCode.length == 9 || sanitizedCode.length == 11);
+            BOOL hasExpectedSeparator = (sanitizedCode.length > 6 && [sanitizedCode characterAtIndex:6] == ':');
+            if (!isValidLength || !hasExpectedSeparator)
+            {
+                NSLog(@"Invalid Action Replay format: %@", sanitizedCode);
+                return NO;
+            }
+        }
+
+        char cheatCString[32];
+        if (![sanitizedCode getCString:cheatCString maxLength:sizeof(cheatCString) encoding:NSUTF8StringEncoding])
+        {
+            NSLog(@"Failed to convert to cString: %@", sanitizedCode);
+            return NO;
+        }
+
+        int cheatCount = (int)self.cheatCount;
+        NSInteger length = decode_cheat(cheatCString, cheatCount);
+        if (length == 0)
+        {
+            NSLog(@"Failed to decode cheat: %@", sanitizedCode);
+            return NO;
+        }
+
+        cheatlist[self.cheatCount].enable = 1;
+        // The bridge owns this!
+        self.cheatCount++;
+        // The C-core owns this! Without this, the cheats don't apply at all.
+        maxcheats++;
+        addedCheat = YES;
     }
     
-    return NO;
+    return addedCheat;
 }
 
 - (void)resetCheats

--- a/Sources/GPGXBridge/GPGXEmulatorBridge.m
+++ b/Sources/GPGXBridge/GPGXEmulatorBridge.m
@@ -260,27 +260,91 @@ int GPGXGameSaveSize = 0x10000;
 
 - (BOOL)addCheatCode:(NSString *)cheatCode type:(NSString *)type
 {
-    NSMutableString *mutableCheatCode = [cheatCode mutableCopy];
-    char cheatCString[32];
-    if (![mutableCheatCode getCString:cheatCString maxLength:sizeof(cheatCString) encoding:NSUTF8StringEncoding])
+    NSArray<NSString *> *codes = [cheatCode componentsSeparatedByString:@"\n"];
+    
+    for (NSString *code in codes)
     {
-        NSLog(@"Failed to convert to cString: %@", mutableCheatCode);
-        return NO;
+        // Normalize input first: trim whitespace/newlines and uppercase for consistent validation
+        NSString *normalized = [[code stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] uppercaseString];
+
+        // Build legal character set based on type
+        NSMutableCharacterSet *legalCharacters = nil;
+        if ([type isEqualToString:CheatTypeActionReplay])
+        {
+            legalCharacters = [[NSMutableCharacterSet hexadecimalCharacterSet] mutableCopy];
+            [legalCharacters addCharactersInString:@":"];
+        }
+        else if ([type isEqualToString:CheatTypeGameGenie])
+        {
+            legalCharacters = [[NSMutableCharacterSet characterSetWithCharactersInString:[NSString stringWithUTF8String:ggvalidchars]] mutableCopy];
+            [legalCharacters addCharactersInString:@"-"];
+        }
+        else
+        {
+            // Not a supported type!
+            return NO;
+        }
+
+        // Allow spaces (we'll strip them) during validation
+        NSMutableCharacterSet *legalCharactersSet = [legalCharacters mutableCopy];
+        [legalCharactersSet addCharactersInString:@" "];
+
+        // Validate characters against the allowed set
+        NSRange illegalRange = [normalized rangeOfCharacterFromSet:[legalCharactersSet invertedSet]];
+        if (illegalRange.location != NSNotFound)
+        {
+            unichar offendingCharacter = [normalized characterAtIndex:illegalRange.location];
+            NSLog(@"Offending character: %C", offendingCharacter);
+            return NO;
+        }
+        
+        if ([type isEqualToString:CheatTypeActionReplay] || [type isEqualToString:CheatTypeGameGenie])
+        {
+            // Remove spaces; keep hyphens because decode_cheat expects them for 16-bit GG (ABCD-EFGH)
+            NSString *sanitizedCode = [[normalized stringByReplacingOccurrencesOfString:@" " withString:@""] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+
+            // Basic length checks per type
+            if ([type isEqualToString:CheatTypeGameGenie])
+            {
+                // Accept 16-bit GG codes in form ABCD-EFGH (length 9)
+                if (sanitizedCode.length != 9)
+                {
+                    return NO;
+                }
+            }
+            else if ([type isEqualToString:CheatTypeActionReplay])
+            {
+                // Expect MD AR as AAAAAA:DDDD (length 11) or SMS as xxAAAA:DD (length 9)
+                if (!(sanitizedCode.length == 11 || sanitizedCode.length == 9))
+                {
+                    return NO;
+                }
+            }
+            
+            char cheatCString[32];
+            if (![sanitizedCode getCString:cheatCString maxLength:sizeof(cheatCString) encoding:NSUTF8StringEncoding])
+            {
+                NSLog(@"Failed to convert to cString: %@", sanitizedCode);
+                return NO;
+            }
+            int cheatCount = (int)self.cheatCount;
+            NSInteger length = decode_cheat(cheatCString, cheatCount);
+            if (length == 0)
+            {
+                NSLog(@"Failed to decode cheat: %@", sanitizedCode);
+                return NO;
+            }
+            
+            cheatlist[self.cheatCount].enable = 1;
+                     
+            self.cheatCount++;
+            
+            return YES;
+            
+        }
     }
-    int cheatCount = (int)self.cheatCount;
-    NSInteger length = decode_cheat(cheatCString, cheatCount);
-    if (length == 0)
-    {
-        NSLog(@"Failed to decode cheat: %@", mutableCheatCode);
-        return NO;
-    }
     
-    cheatlist[self.cheatCount].enable = 1;
-    
-    self.cheatCount++;
-    maxcheats++;
-    
-    return YES;
+    return NO;
 }
 
 - (void)resetCheats

--- a/Sources/GPGXBridge/GPGXEmulatorBridge.m
+++ b/Sources/GPGXBridge/GPGXEmulatorBridge.m
@@ -72,8 +72,6 @@ int GPGXGameSaveSize = 0x10000;
 @property (nonatomic, readonly) NSMutableData *audioBuffer;
 @property (nonatomic, readonly) NSMutableData *videoBuffer;
 
-@property (nonatomic, readwrite) NSInteger cheatCount;
-
 @end
 
 @implementation GPGXEmulatorBridge
@@ -99,7 +97,6 @@ int GPGXGameSaveSize = 0x10000;
     {
         _audioBuffer = [[NSMutableData alloc] initWithLength:2048 * 2 * sizeof(int16_t)];
         _videoBuffer = [[NSMutableData alloc] initWithLength:GPGXVideoWidth * GPGXVideoHeight * sizeof(uint32_t)];
-        _cheatCount = 0;
     }
     
     return self;
@@ -327,18 +324,20 @@ int GPGXGameSaveSize = 0x10000;
         return NO;
     }
     
-    int cheatCount = (int)self.cheatCount;
-    NSInteger length = decode_cheat(cheatCString, cheatCount);
+    if (maxcheats >= MAX_CHEATS)
+    {
+        NSLog(@"Maximum number of cheats reached.");
+        return NO;
+    }
+
+    NSInteger length = decode_cheat(cheatCString, maxcheats);
     if (length == 0)
     {
         NSLog(@"Failed to decode cheat: %@", sanitizedCode);
         return NO;
     }
 
-    cheatlist[self.cheatCount].enable = 1;
-    // The bridge owns this!
-    self.cheatCount++;
-    // The C-core owns this! Without this, the cheats don't apply at all.
+    cheatlist[maxcheats].enable = 1;
     maxcheats++;
     addedCheat = YES;
     
@@ -348,7 +347,6 @@ int GPGXGameSaveSize = 0x10000;
 - (void)resetCheats
 {
     clear_cheats();
-    self.cheatCount = 0;
     maxcheats = 0;
 }
 

--- a/Sources/GPGXBridge/GPGXEmulatorBridge.m
+++ b/Sources/GPGXBridge/GPGXEmulatorBridge.m
@@ -260,23 +260,18 @@ int GPGXGameSaveSize = 0x10000;
 
 - (BOOL)addCheatCode:(NSString *)cheatCode type:(NSString *)type
 {
-    
-    
     NSMutableString *mutableCheatCode = [cheatCode mutableCopy];
-    
-//    if ([type isEqualToString:CheatTypeActionReplay])
-//    {
-//        //
-//    }
-//    else if ([type isEqualToString:CheatTypeGameGenie])
-//    {
-//        [mutableCheatCode insertString:@"-" atIndex:4];
-//    }
-//    
-    NSInteger length = decode_cheat(mutableCheatCode.UTF8String, self.cheatCount);
+    char cheatCString[32];
+    if (![mutableCheatCode getCString:cheatCString maxLength:sizeof(cheatCString) encoding:NSUTF8StringEncoding])
+    {
+        NSLog(@"Failed to convert to cString: %@", mutableCheatCode);
+        return NO;
+    }
+    int cheatCount = (int)self.cheatCount;
+    NSInteger length = decode_cheat(cheatCString, cheatCount);
     if (length == 0)
     {
-        NSLog(@"Failed to decode cheat: %@", cheatCode);
+        NSLog(@"Failed to decode cheat: %@", mutableCheatCode);
         return NO;
     }
     

--- a/Sources/GPGXBridge/GPGXTypes.h
+++ b/Sources/GPGXBridge/GPGXTypes.h
@@ -14,3 +14,6 @@
 
 // Extensible Enums
 FOUNDATION_EXPORT GameType const GameTypeGenesis NS_SWIFT_NAME(genesis);
+
+FOUNDATION_EXPORT CheatType const CheatTypeGameGenie;
+FOUNDATION_EXPORT CheatType const CheatTypeActionReplay;

--- a/Sources/GPGXBridge/GPGXTypes.m
+++ b/Sources/GPGXBridge/GPGXTypes.m
@@ -9,3 +9,6 @@
 #import "GPGXTypes.h"
 
 GameType const GameTypeGenesis = @"com.rileytestut.delta.game.genesis";
+
+CheatType const CheatTypeGameGenie = @"gameGenie";
+CheatType const CheatTypeActionReplay = @"actionReplay";

--- a/Sources/GPGXDeltaCore/GPGX.swift
+++ b/Sources/GPGXDeltaCore/GPGX.swift
@@ -38,7 +38,9 @@ public struct GPGX: DeltaCoreProtocol, Sendable
     public var videoFormat: VideoFormat { VideoFormat(format: .bitmap(.bgra8), dimensions: CGSize(width: 720, height: 576)) }
 
     public var supportedCheatFormats: Set<CheatFormat> {
-        return []
+        let gameGenieFormat = CheatFormat(name: NSLocalizedString("Game Genie", comment: ""), format: "XXXX-YYYY", type: .gameGenie, allowedCodeCharacters: CharacterSet.uppercaseLetters.union(.decimalDigits))
+        let actionReplayFormat = CheatFormat(name: NSLocalizedString("Action Replay", comment: ""), format: "XXXXXX:YYYY", type: .actionReplay)
+        return [gameGenieFormat, actionReplayFormat]
     }
     
     #if SWIFT_PACKAGE


### PR DESCRIPTION
This is a PR designed to enable both Action Replay and Game Genie cheats for the Sega Genesis. I've confirmed this works, but with Game Genie, if the screen turns red, you'll likely need to enter a master code, as the red screen is an anti-privacy measure.

Materials for Testing:
1. Use the game Sonic the Hedgehog 2 for Sega Genesis (it's amazing anyway)
2. The following cheats need to be added, and I'll list their effects:
2a. Game Genie:
- Mega Jump: ACZA-C4C6 (Sonic will jump _extremely_ high)
- Master Code: F2BT-AA24 (needed or the game won't start)
- Alternate Master Code: ATBT-AA42 (another master code. Might have to enable one or both, as I am not sure the difference)
2b. Action Replay (weird and not as straightforward as Game Genie codes and results)
- 224 Rings: FFFE21:00E0
3. Run the game and try AR and GG codes separately and together. Observe the intended effects as included in the cheat description. Note that this requires a master code because otherwise the game will sometimes show a red screen as an anti-piracy measure.

Correctness criteria:
1. The cheats work as expected
2. Enabling/disabling the cheats does not cause a crash
3. Cheats are persisted and activated upon entry

PR Purpose:
I updated this PR to include much more thorough validation for cheats and plenty of graceful failure for edge cases and bad formats. This took some inspiration from how the GBA core handles cheats, except the Genesis core has its own decode_cheat method, so I had to essentially prepare a safe cheat entry to hand over to that method, hence why it deviates some from the design of the GBA implementation.

If you have any additional questions, please let me know, and I'll be happy to help!